### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI & Lint
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/x7finance/telegram-deployer/security/code-scanning/2](https://github.com/x7finance/telegram-deployer/security/code-scanning/2)

To fix this issue, we need to explicitly declare the `permissions` block in the workflow YAML, setting the minimum possible privileges for the job(s). In this case, since none of the steps require writing to the repository or interacting with issues or pull requests, the most restrictive safe option is `contents: read`. The `permissions` block can be added at the workflow level (applies to all jobs), or at the individual job level. Following the source code style and simplicity, adding it at the root level (immediately after the `name:` line) is best.

**Specifically:**  
- Edit `.github/workflows/ci.yml`.
- Insert the following after line 1:  
  ```yaml
  permissions:
    contents: read
  ```
  This ensures all jobs receive only `contents: read` privileges via GITHUB_TOKEN.

No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
